### PR TITLE
Preserve registers when deleting whitespace at EOF

### DIFF
--- a/lua/tidy/init.lua
+++ b/lua/tidy/init.lua
@@ -59,7 +59,7 @@ function M.setup(opts)
       vim.cmd([[:keepjumps keeppatterns %s/\s\+$//e]])
 
       -- delete lines @ eof
-      vim.cmd([[:keepjumps keeppatterns silent! 0;/^\%(\n*.\)\@!/,$d]])
+      vim.cmd([[:keepjumps keeppatterns silent! 0;/^\%(\n*.\)\@!/,$d_]])
 
       reset_cursor_pos(cursor_pos)
     end,


### PR DESCRIPTION
I wanted to move some code from one file to another, but when I saved the register was overridden with the whitespace.