### PR TITLE
Also delete leading blank lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An [autocommand](https://neovim.io/doc/user/autocmd.html) that removes all
 
     - trailing whitespace
-    - empty lines at the end of the buffer
+    - empty lines at the beginning and end of the buffer
 
 on every `BufWritePre`.
 


### PR DESCRIPTION
It makes sense to also delete leading blank lines, not just trailing blank lines. The only problem with my implementation is this: If the plugin deletes trailing blank lines, it will not correct your cursor position if your cursor was somewhere in the middle of the file (i.e. not on any of the blank lines or the highest line that is not blank). Try it for yourself to see what I mean. Nonetheless, you won't encounter any errors and it's better than nothing.