### PR TITLE
feat: don't run if editorconfig is detected

### DIFF
--- a/lua/tidy/init.lua
+++ b/lua/tidy/init.lua
@@ -64,7 +64,7 @@ function M.setup(opts)
   vim.api.nvim_create_autocmd("BufWritePre", {
     group = tidy_grp,
     callback = function()
-      if not M.enabled or vim.b.tidy_enabled == false or is_excluded_ft(opts) then
+      if not M.enabled or vim.b.tidy_enabled == false or is_excluded_ft(opts) or not vim.tbl_isempty(vim.b.editorconfig) then
         return false
       end
 


### PR DESCRIPTION
Since in neovim 0.9.0 Editorconfig support is built-in. I think is a good thing to disable this plugin if a `.editorconfig` file is detected. 

If there isn't any `.editorconfig` file neovim puts a buffer variable called `vim.b.editorconfig` and assign to it an empty table.