### PR TITLE
fix: test editorconfig ~= nil

### DIFF
--- a/lua/tidy/init.lua
+++ b/lua/tidy/init.lua
@@ -60,7 +60,7 @@ function M.setup(opts)
 	vim.api.nvim_create_autocmd("BufWritePre", {
     group = tidy_grp,
     callback = function()
-      if not M.enabled or is_excluded_ft(opts) or not vim.tbl_isempty(vim.b.editorconfig) then
+      if not M.enabled or is_excluded_ft(opts) or (vim.b.editorconfig ~= nil and not vim.tbl_isempty(vim.b.editorconfig)) then
         return false
       end
 


### PR DESCRIPTION
When editorconfig is not set, the `BufWritePre` autocommands leads to an error.
Fix includes test for `vim.b.editorconfig ~= nil`.