### PR TITLE
fix: don't error if `vim.b.editorconfig = false`

### DIFF
--- a/lua/tidy/init.lua
+++ b/lua/tidy/init.lua
@@ -72,7 +72,7 @@ function M.setup(opts)
         return false
       end
 
-      if vim.b.editorconfig ~= nil and not vim.tbl_isempty(vim.b.editorconfig) then
+      if vim.b.editorconfig and not vim.tbl_isempty(vim.b.editorconfig) then
         if not M.opts.provide_undefined_editorconfig_behavior then
           return false
         end


### PR DESCRIPTION
Editorconfig support is disabled if `vim.b.editorconfig` is either `nil` (if it was globally disabled) or `false` (if it was disabled per-buffer). Previously the program was only checking that the first condition was true