### PR TITLE
Fix syntax errors in README.md configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ A more full example configuration for lazy.nvim would be:
 {
     "mcauley-penney/tidy.nvim",
     opts = {
-        enabled_on_save = false
-        filetype_exclude = { "markdown", "diff" }
+        enabled_on_save = false,
+        filetype_exclude = { "markdown", "diff" },
     },
     init = function()
-        vim.keymap.set('n', "<leader>tt", require("tidy").toggle, {})
-        vim.keymap.set('n', "<leader>tr", require("tidy").run, {})
-    end
-}
+        vim.keymap.set("n", "<leader>tt", require("tidy").toggle, {})
+        vim.keymap.set("n", "<leader>tr", require("tidy").run, {})
+    end,
+},
 ```
 
 


### PR DESCRIPTION
Lazy Vim config was missing commas.  My formatter standardized the quotes